### PR TITLE
Allow `HTMLOutputStream` to write to a `String`

### DIFF
--- a/Sources/Vaux/HTML/HTMLOutputStream.swift
+++ b/Sources/Vaux/HTML/HTMLOutputStream.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - HTMLOutputStream
 /// A helper class for rendering formatted HTML to a given `TextOutputStream`.
 public class HTMLOutputStream {
-  var output: TextOutputStream
+  public internal(set) var output: TextOutputStream
   
   /// Create an `HTMLOutputStream` that will render `HTML` nodes as HTML text.
   public init(_ output: TextOutputStream, _ tag: String?) {


### PR DESCRIPTION
Currently it's not possible to write the rendered `HTML` to a simple `String` instead of `stdout` or a file, even though `String` conforms to `TextOutputStream`.

Since `String` is a value type, not a reference type, passing it as a first argument makes a copy of that string and the stream writes to a copy. It would be possible to receive a copy that has the rendered content, if `output` was a publicly readable property.

Otherwise you get this error:

<img width="679" alt="Screenshot 2019-06-09 at 14 05 14" src="https://user-images.githubusercontent.com/112310/59159306-c03b2900-8abf-11e9-8546-59b2bd7f4935.png">
