### PR TITLE
Use an enum for the heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ In HTML, a heading is used to specify the weight of certain text, to create a na
 ```swift
 func buildPage() -> HTML {
   html {
-    heading(weight: 2) {
+    heading(.h2) {
       "This is a header"
     }
   }

--- a/Sources/Vaux/Builders.swift
+++ b/Sources/Vaux/Builders.swift
@@ -7,6 +7,16 @@
 
 import Foundation
 
+/// Heading weight for the heading tag.
+public enum HeadingWeight {
+    case h1
+    case h2
+    case h3
+    case h4
+    case h5
+    case h6
+}
+
 /// Inserts the top level `<html>` element into the HTML document, and closes with `</html>` after the contents of the closure.
 /// - Parameters:
 ///   - child: `HTML` content to go inside the `<html></html>` element.
@@ -49,13 +59,10 @@ public func lineBreak() -> HTML {
 
 /// Inserts a `<h1>` element (given the specified weight) into the
 /// - Parameters:
-///   - weight: The weight of the heading, such as `<h1>` or `<h4>`. The weight must be specified as between 1 and 6.
+///   - weight: The weight of the heading, such as `<h1>` or `<h4>`.
 ///   - child: `HTML` content to go inside the `<h1></h1>` element.
-public func heading(weight: Int, @HTMLBuilder child: () -> HTML) -> HTML {
-  var weight = weight
-  if weight < 1 { weight = 1 }
-  if weight > 6 { weight = 6 }
-  return HTMLNode(tag: "h\(weight)", child: child())
+public func heading(_ weight: HeadingWeight, @HTMLBuilder child: () -> HTML) -> HTML {
+  return HTMLNode(tag: "\(weight)", child: child())
 }
 
 /// Inserts a `<p>` element into the HTML document, and closes with `</p>` after the contents of the closure.

--- a/Tests/VauxTests/VauxTests.swift
+++ b/Tests/VauxTests/VauxTests.swift
@@ -56,7 +56,6 @@ final class VauxTests: XCTestCase {
       html {
         body {
           link(url: url, label: "google")
-          lineBreak()
         }
       }
     }
@@ -216,16 +215,14 @@ final class VauxTests: XCTestCase {
     func pageWithHeading() -> HTML {
       html {
         body {
-          heading(weight: 1) {
+          heading(.h1) {
             "This is a heading of weight 1"
           }
-          heading(weight: 3) {
+          heading(.h3) {
             "This is a heading of weight 3"
           }
           paragraph {
-            "Four score and "
-            emphasis { "seven" }
-            " years ago..."
+            "Four score and seven years ago..."
           }
         }.style([StyleAttribute(key: "background-color", value: "blue"),
                  StyleAttribute(key: "color", value: "red")])
@@ -242,7 +239,7 @@ final class VauxTests: XCTestCase {
                   This is a heading of weight 3
                 </h3>
                 <p>
-                  Four score and <em>seven</em> years ago...
+                  Four score and seven years ago...
                 </p>
               </body>
             </html>


### PR DESCRIPTION
I think the usage of an enum makes the code clearer. It also prevent from weird values (anything else than 1 to 6).