### PR TITLE
Add the type option as an attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,26 @@ This will render like so:
 </html>
 ```
 
+### `type=mime`
+
+In HTML, you can specify the use of a specific type for some tags, like `link`, `script`, or `input`. In your Swift function, write this:
+
+```swift
+func buildPage() -> HTML {
+  html {
+    linkStylesheet(url: "/tmp/style.css").type("text/css")
+  }
+}
+```
+This HTML will render like so:
+
+```html
+<!DOCTYPE html>
+<html>
+  <link type="text/css" rel="stylesheet" href="/tmp/style.css">
+</html>
+```
+
 ### Custom attributes
 
 This library aims to cover all possible HTML attributes. As this library grows, it is important to have the ability to allow you to create any attribute you need. In your Swift function, write this:

--- a/Sources/Vaux/Builders.swift
+++ b/Sources/Vaux/Builders.swift
@@ -223,6 +223,23 @@ extension HTML {
     return attr("bgcolor", hexCode)
   }
   
+  /// Allow you to specify a media type for a HTML element.
+  ///
+  /// This could  be used for link,  script, input, and any other tags which support it.
+  /// - Note: Look at IANA Media Types for a complete list of standard media types.
+  /// - Example: This:
+  /// ```
+  /// linkStyleSheet(url: "style.css").type("text/css")
+  /// ```
+  /// yields this:
+  /// ```
+  /// <link type="text/css" rel="stylesheet" href="style.css"/>
+  /// ```
+  /// - Parameter mime: The Internet media type of the linked document.
+  public func type(_ mime: String) -> HTML {
+    return attr("type", mime)
+  }
+  
   /// Allows you to specify inline CSS (cascading style sheets) style for a HTML element.
   /// - Note: Inline CSS style on HTML elements is often times frowned upon. It is recommended to instead use a link to a separate stylesheet that is defined on its own. You can do this with the `linkStylesheet()` builder.
   /// - Example: This:

--- a/Tests/VauxTests/VauxTests.swift
+++ b/Tests/VauxTests/VauxTests.swift
@@ -319,7 +319,7 @@ final class VauxTests: XCTestCase {
   func testNestedPages() {
     func masterPage() -> HTML {
       html {
-        linkStylesheet(url: "/tmp/style.css")
+        linkStylesheet(url: "/tmp/style.css").type("text/css")
         body {
           childPage()
         }
@@ -333,7 +333,7 @@ final class VauxTests: XCTestCase {
     let correctHTML = """
             <!DOCTYPE html>
             <html>
-              <link rel="stylesheet" href="/tmp/style.css"/>
+              <link type="text/css" rel="stylesheet" href="/tmp/style.css"/>
               <body>
                 <div id="abcd">
                   Some div content


### PR DESCRIPTION
Add the type attribute as a dedicated one.
Useful for CSS, script and forms.