### PR TITLE
Visibility issues

### DIFF
--- a/Sources/Vaux/FileHelper.swift
+++ b/Sources/Vaux/FileHelper.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 public struct Filepath {
-  var name: String
-  var path: String
+  public var name: String
+  public var path: String
 }
 
 public class VauxFileHelper {

--- a/Sources/Vaux/HTML/HTMLNode.swift
+++ b/Sources/Vaux/HTML/HTMLNode.swift
@@ -68,13 +68,13 @@ struct HTMLNode: HTML {
 
 // MARK: - Concatenative HTML Attributes
 public struct Attribute {
-  let key: String
-  let value: String?
+  public let key: String
+  public let value: String?
 }
 
 public struct StyleAttribute {
-  let key: String
-  let value: String
+  public let key: String
+  public let value: String
 }
 
 /// Wraps an HTML object with a given attribute. these attributes are collected


### PR DESCRIPTION
When used externally, the visibility prevents to create a `Filepath`, and `Attribute` or a `StyleAttribute`.