### PR TITLE
String output support.

### DIFF
--- a/Sources/Vaux/HTML/HTMLNode.swift
+++ b/Sources/Vaux/HTML/HTMLNode.swift
@@ -92,6 +92,16 @@ public struct StyleAttribute {
   }
 }
 
+/// Allows to init [StyleAttribute] by [String: String] literal.
+extension Array : ExpressibleByDictionaryLiteral where Element == StyleAttribute {
+    public typealias Key = String
+    public typealias Value = String
+    
+    public init(dictionaryLiteral elements: (String, String)...) {
+        self.init(elements.map { .init(key: $0.0, value: $0.1) } )
+    }
+}
+
 /// Wraps an HTML object with a given attribute. these attributes are collected
 /// while walking the node hierarchy and finally printed when printing an
 /// `HTMLNode`.

--- a/Sources/Vaux/Vaux.swift
+++ b/Sources/Vaux/Vaux.swift
@@ -12,44 +12,73 @@ import Foundation
 /// - Parameters:
 ///   - outputLocation: Chooses whether to render the document to stdout, which is effective for quick testing or to a file with a specified name and path, which will always end in `.html`
 public class Vaux {
-  public enum VauxOutput {
-    case stdout
-    case file(filepath: Filepath)
-  }
-
-  /// Initializer must be public to create instance
-  public init() { }
-
-  /// Default parameter for where render output goes
-  public var outputLocation: VauxOutput = .stdout
-
-  /// Handles retrieving correct `HTMLOutputStream` for where rendered document will go
-  private func getStream(for content: HTML) throws -> HTMLOutputStream {
-    switch outputLocation {
-    case .stdout:
-      return HTMLOutputStream(FileHandle.standardOutput, content.getTag())
-    case .file(let filepath):
-      do {
-        guard let url = VauxFileHelper.createFile(filepath) else {
-          throw VauxFileHelperError.noFile
+    public enum VauxOutput {
+        case stdout
+        case file(name: String, path: String)
+        case custom(TextOutputStream & AnyObject)
+    
+        public static func string(_ value: inout String) -> VauxOutput {
+            .custom(Wrapper(&value))
         }
-        let handler = try FileHandle(forWritingTo: url)
-        return HTMLOutputStream(handler, content.getTag())
-      } catch let error {
-        throw error
-      }
     }
-  }
+  
+  
+    /// Initializer must be public to create instance
+    public init() { }
+  
+    /// Default parameter for where render output goes
+    public var outputLocation: VauxOutput = .stdout
+  
+    /// Handles retrieving correct `HTMLOutputStream` for where rendered document will go
+    private func getStream(for content: HTML) throws -> HTMLOutputStream {
+        switch outputLocation {
+        case .stdout:
+            return HTMLOutputStream(FileHandle.standardOutput, content.getTag())
+        case let .custom(stream):
+            return HTMLOutputStream(stream, content.getTag())
+        case .file(let filename, let path):
+            do {
+                guard let url = VauxFileHelper.createFile(named: filename, path: path) else {
+                    throw VauxFileHelperError.noFile
+                }
+                let handler = try FileHandle(forWritingTo: url)
+                return HTMLOutputStream(handler, content.getTag())
+            } catch let error {
+                throw error
+            }
+        }
+    }
+  
+    /// Renders `HTML` into a static HTML file.
+    /// - Parameters:
+    ///   - content: A function that builds `HTML` that you intend to render.
+    public func render(_ content: HTML) throws {
+        do {
+            let stream = try getStream(for: content)
+            content.renderAsHTML(into: stream, attributes: [])
+        } catch let error {
+            throw error
+        }
+    }
+    
+}
 
-  /// Renders `HTML` into a static HTML file.
-  /// - Parameters:
-  ///   - content: A function that builds `HTML` that you intend to render.
-  public func render(_ content: HTML) throws {
-    do {
-      let stream = try getStream(for: content)
-      content.renderAsHTML(into: stream, attributes: [])
-    } catch let error {
-      throw error
+private extension Vaux.VauxOutput {
+    
+    @propertyWrapper
+    private class Wrapper: TextOutputStream {
+        func write(_ string: String) {
+            self.value.pointee += string
+        }
+        
+        var value: UnsafeMutablePointer<String>
+        init(_ value: UnsafeMutablePointer<String>) {
+            self.value = value
+        }
+        var wrappedValue: String {
+            get { value.pointee }
+            set { value.pointee = newValue }
+        }
     }
-  }
+    
 }

--- a/Sources/Vaux/Vaux.swift
+++ b/Sources/Vaux/Vaux.swift
@@ -22,9 +22,10 @@ public class Vaux {
         }
     }
   
-  
     /// Initializer must be public to create instance
-    public init() { }
+    public init(output: VauxOutput = .stdout) {
+        self.output = output
+    }
   
     /// Default parameter for where render output goes
     public var outputLocation: VauxOutput = .stdout
@@ -49,7 +50,7 @@ public class Vaux {
         }
     }
   
-    /// Renders `HTML` into a static HTML file.
+    /// Renders `HTML` into a static HTML output.
     /// - Parameters:
     ///   - content: A function that builds `HTML` that you intend to render.
     public func render(_ content: HTML) throws {
@@ -57,6 +58,20 @@ public class Vaux {
             let stream = try getStream(for: content)
             content.renderAsHTML(into: stream, attributes: [])
         } catch let error {
+            throw error
+        }
+    }
+    
+    /// Renders `HTML` into a static HTML string.
+    /// - Parameters:
+    ///   - content: A function that builds `HTML` that you intend to render.
+    /// - Returns: HTML string.
+    public static func render(_ content: () -> HTML) throws -> String {
+        do {
+            var result = ""
+            try Vaux(output: .string(&result)).render(content())
+            return result
+        } catch {
             throw error
         }
     }

--- a/Sources/Vaux/Vaux.swift
+++ b/Sources/Vaux/Vaux.swift
@@ -14,7 +14,7 @@ import Foundation
 public class Vaux {
     public enum VauxOutput {
         case stdout
-        case file(name: String, path: String)
+        case file(filepath: Filepath)
         case custom(TextOutputStream & AnyObject)
     
         public static func string(_ value: inout String) -> VauxOutput {
@@ -24,7 +24,7 @@ public class Vaux {
   
     /// Initializer must be public to create instance
     public init(output: VauxOutput = .stdout) {
-        self.output = output
+        self.outputLocation = output
     }
   
     /// Default parameter for where render output goes
@@ -37,9 +37,9 @@ public class Vaux {
             return HTMLOutputStream(FileHandle.standardOutput, content.getTag())
         case let .custom(stream):
             return HTMLOutputStream(stream, content.getTag())
-        case .file(let filename, let path):
+        case .file(let filepath):
             do {
-                guard let url = VauxFileHelper.createFile(named: filename, path: path) else {
+                guard let url = VauxFileHelper.createFile(filepath) else {
                     throw VauxFileHelperError.noFile
                 }
                 let handler = try FileHandle(forWritingTo: url)


### PR DESCRIPTION
I've implemented custom output support, and one static method to to support strings out-of-the-box.
Example:
```swift
var str = ""
let vaux = Vaux()
vaux.output = .string(&str)
```

plus [StyleAttribute] is now expressible by [String: String] literals